### PR TITLE
Add TerminalDxe build and workspace helper; update README

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,11 +22,11 @@ The X64 binary above was built on this branch for use with the Minix Z350-0dB's 
 ## Building the firmware with Nix
 
 A `default.nix` expression is provided so that the EDK II UEFI Shell and the
-FTDI USB Serial DXE driver can be reproduced on NixOS. Evaluating the
-expression reuses the pre-built shell from `nixpkgs#edk2-uefi-shell`, fetches
-the upstream EDK II sources necessary for the driver, builds it with the
-standard BaseTools toolchain, and then stages both firmware binaries under
-`$out/share/firmware`.
+FTDI USB Serial plus Terminal DXE drivers can be reproduced on NixOS.
+Evaluating the expression reuses the pre-built shell from
+`nixpkgs#edk2-uefi-shell`, fetches the upstream EDK II sources necessary for the
+drivers, builds them with the standard BaseTools toolchain, and then stages the
+firmware binaries under `$out/share/firmware`.
 
 To build the firmware, run:
 
@@ -38,10 +38,11 @@ The resulting symlink named `result` will contain:
 
 * `share/firmware/Shell.efi`
 * `share/firmware/FtdiUsbSerialDxe.efi`
+* `share/firmware/TerminalDxe.efi`
 * `share/firmware/Shell.nixpkgs.efi` (the reference shell binary that ships with
   `nixpkgs#edk2-uefi-shell`)
 
-These two binaries can be copied onto a FAT-formatted USB stick and loaded by
+These three binaries can be copied onto a FAT-formatted USB stick and loaded by
 UEFI firmware on the Minix Z350-0dB fanless mini-PC. The driver may also be
 loaded from the UEFI shell using `load fs0:\EFI\FtdiUsbSerialDxe.efi` once the
 USB stick has been mounted.


### PR DESCRIPTION
### Motivation
- Enable building and staging the Terminal DXE driver alongside the existing UEFI shell and FTDI USB serial driver in the Nix output.
- Reduce duplication by centralizing EDK II workspace setup for multiple derivations. 
- Keep documentation consistent with the added artifact by updating the `README.md` to list `TerminalDxe.efi`.

### Description
- Add a reusable `mkWorkspace` shell snippet in `nix/edk2-shell-ftdi.nix` that copies `edk2-platforms` and `edk2-non-osi` and exports `PACKAGES_PATH` for EDK II builds. 
- Add a new `terminal` derivation via `edk2.mkDerivation` to build `MdeModulePkg/Universal/Console/TerminalDxe/TerminalDxe.inf` and install its produced `TerminalDxe.efi`. 
- Install `TerminalDxe.efi` into the top-level package under `$out/share/firmware` and expose the new `terminal` derivation via `passthru`, and update package `description`/`longDescription`. 
- Update `README.md` to mention the Terminal DXE driver and to list the three staged firmware binaries under the `result` symlink.

### Testing
- Attempted to run `nix-build` in this environment to validate the Nix derivations, but the command failed because `nix-build` is not available in the execution environment. 
- No other automated tests were executed for this change in the current environment. 
- Manual inspection of the updated `README.md` confirms that `share/firmware/TerminalDxe.efi` is listed in the output artifacts.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_697eb18241b4832f8dcad99b1d27bb68)