### PR TITLE
Add ConSplitterDxe to Nix firmware outputs

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ The X64 binary above was built on this branch for use with the Minix Z350-0dB's 
 ## Building the firmware with Nix
 
 A `default.nix` expression is provided so that the EDK II UEFI Shell and the
-FTDI USB Serial plus Terminal DXE drivers can be reproduced on NixOS.
+FTDI USB Serial plus Terminal and ConSplitter DXE drivers can be reproduced on NixOS.
 Evaluating the expression reuses the pre-built shell from
 `nixpkgs#edk2-uefi-shell`, fetches the upstream EDK II sources necessary for the
 drivers, builds them with the standard BaseTools toolchain, and then stages the
@@ -39,10 +39,11 @@ The resulting symlink named `result` will contain:
 * `share/firmware/Shell.efi`
 * `share/firmware/FtdiUsbSerialDxe.efi`
 * `share/firmware/TerminalDxe.efi`
+* `share/firmware/ConSplitterDxe.efi`
 * `share/firmware/Shell.nixpkgs.efi` (the reference shell binary that ships with
   `nixpkgs#edk2-uefi-shell`)
 
-These three binaries can be copied onto a FAT-formatted USB stick and loaded by
+These binaries can be copied onto a FAT-formatted USB stick and loaded by
 UEFI firmware on the Minix Z350-0dB fanless mini-PC. The driver may also be
 loaded from the UEFI shell using `load fs0:\EFI\FtdiUsbSerialDxe.efi` once the
 USB stick has been mounted.


### PR DESCRIPTION
### Motivation

- Provide a Nix-based build for the `ConSplitterDxe` DXE driver so the `ConSplitterDxe.efi` artifact is produced alongside the existing shell and drivers.

### Description

- Add a new derivation `consplitter` in `nix/edk2-shell-ftdi.nix` that builds `MdeModulePkg/Universal/Console/ConSplitterDxe/ConSplitterDxe.inf` and produces `ConSplitterDxe.efi`.
- Install the built `ConSplitterDxe.efi` into the top-level output at `share/firmware/ConSplitterDxe.efi` and expose the derivation via `passthru` as `consplitter`.
- Update `README.md` to document the new `share/firmware/ConSplitterDxe.efi` artifact and adjust the package description to mention the new driver.

### Testing

- No automated tests were run as part of this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_697eb6a94180832fa41b92a2fa43a07e)